### PR TITLE
fix: error LNK2019: unresolved external symbol WINRT_IMPL_RoGetActivationFactory

### DIFF
--- a/miniav_ffi/miniav_c/src/screen/windows/screen_context_win_wgc.cpp
+++ b/miniav_ffi/miniav_c/src/screen/windows/screen_context_win_wgc.cpp
@@ -33,6 +33,7 @@
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "dxgi.lib")
 #pragma comment(lib, "dwmapi.lib")
+#pragma comment(lib, "runtimeobject.lib")
 
 // --- WinRT and Dispatcher Queue Management ---
 static std::atomic<int> g_wgc_init_count = 0;


### PR DESCRIPTION
fixes: #9 